### PR TITLE
Reduce email volume on project and group membership

### DIFF
--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -268,11 +268,11 @@ class NotificationService
 
   # Group invite
   def invite_group_member(group_member, token)
-    # mailer.member_invited_email(group_member.real_source_type, group_member.id, token).deliver_later
+    mailer.member_invited_email(group_member.real_source_type, group_member.id, token).deliver_later
   end
 
   def accept_group_invite(group_member)
-    # mailer.member_invite_accepted_email(group_member.real_source_type, group_member.id).deliver_later
+    mailer.member_invite_accepted_email(group_member.real_source_type, group_member.id).deliver_later
   end
 
   def decline_group_invite(group_member)

--- a/app/services/notification_service.rb
+++ b/app/services/notification_service.rb
@@ -257,7 +257,7 @@ class NotificationService
   def new_project_member(project_member)
     return true unless project_member.notifiable?(:mention, skip_read_ability: true)
 
-    mailer.member_access_granted_email(project_member.real_source_type, project_member.id).deliver_later
+    # mailer.member_access_granted_email(project_member.real_source_type, project_member.id).deliver_later
   end
 
   def update_project_member(project_member)
@@ -268,11 +268,11 @@ class NotificationService
 
   # Group invite
   def invite_group_member(group_member, token)
-    mailer.member_invited_email(group_member.real_source_type, group_member.id, token).deliver_later
+    # mailer.member_invited_email(group_member.real_source_type, group_member.id, token).deliver_later
   end
 
   def accept_group_invite(group_member)
-    mailer.member_invite_accepted_email(group_member.real_source_type, group_member.id).deliver_later
+    # mailer.member_invite_accepted_email(group_member.real_source_type, group_member.id).deliver_later
   end
 
   def decline_group_invite(group_member)
@@ -290,7 +290,7 @@ class NotificationService
   def new_group_member(group_member)
     return true unless group_member.notifiable?(:mention)
 
-    mailer.member_access_granted_email(group_member.real_source_type, group_member.id).deliver_later
+    # mailer.member_access_granted_email(group_member.real_source_type, group_member.id).deliver_later
   end
 
   def update_group_member(group_member)


### PR DESCRIPTION
This PR reduces the email volume emitted by GitLab by _not_ sending out the "You have been granted access" emails.

Fixes #10 
