### PR TITLE
fix: add migration to change namespace_tag namespace_id SL-2642

### DIFF
--- a/db/migrate/20190619121045_change_namespace_tag_namespace_id.rb
+++ b/db/migrate/20190619121045_change_namespace_tag_namespace_id.rb
@@ -1,0 +1,34 @@
+class ChangeNamespaceTagNamespaceId < ActiveRecord::Migration
+  include Gitlab::Database::MigrationHelpers
+
+  DOWNTIME = true
+  DOWNTIME_REASON = 'This migration requires downtime to avoid possible collisions in namespace_tags table.'
+
+  disable_ddl_transaction!
+
+  def up
+    if Gitlab::Database.postgresql?
+      execute <<-SQL
+        UPDATE namespace_tags "nt"
+        SET namespace_id = n.id
+        FROM namespaces "n"
+        WHERE n.owner_id is NOT NULL
+        AND n.type IS NULL
+        AND nt.namespace_id = n.owner_id
+      SQL
+    end
+  end
+
+  def down
+    if Gitlab::Database.postgresql?
+      execute <<-SQL
+        UPDATE namespace_tags "nt"
+        SET namespace_id = n.owner_id
+        FROM namespaces "n"
+        WHERE n.owner_id is NOT NULL
+        AND n.type IS NULL
+        AND nt.namespace_id = n.id
+      SQL
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a data migration to change namespace_tag namespace_id from a user id to an actual namespace id.

https://stoplightio.atlassian.net/browse/SL-2642